### PR TITLE
Fix dropout implementation

### DIFF
--- a/keras_wrn/wrn.py
+++ b/keras_wrn/wrn.py
@@ -22,7 +22,7 @@ def main_block(x, filters, n, strides, dropout):
 		x_res = Activation('relu')(x_res)
 		x_res = Conv2D(filters, (3,3), padding="same")(x_res)
 		# Apply dropout if given
-		if dropout: x_res = Dropout(dropout)(x)
+		if dropout: x_res = Dropout(dropout)(x_res)
 		# Second part
 		x_res = BatchNormalization()(x_res)
 		x_res = Activation('relu')(x_res)


### PR DESCRIPTION
Accidental use of x instead of x_res meant that when dropout was used only one convolutional layer would be used in each residual part instead of two